### PR TITLE
requirements: Remove requirement docutils<0.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx
 sphinx_rtd_theme
-docutils<0.15        # 2019-07-21, upstream breakage with Sphinx #6594
+docutils!=0.15        # 2019-07-21, upstream breakage with Sphinx #6594
 PyYAML
 sphinx_ext_substitution


### PR DESCRIPTION
- docutils 0.15 was just broken with Sphinx, so I had pinned
  docutils<0.15.  That was a year ago, so removed now.
- Now I made it docutils!=0.15.  This isn't perfect, since it won't
  work to exclude another version, but... it's something?  I was also
  thinking to just remove the negative-pin because I think it's not so
  important, but this levaes a bit of documentation.  It can be
  removed anytime.
- To review: is this a sane approach?