### PR TITLE
Consistently use `>` everywhere

### DIFF
--- a/courses/A.yaml
+++ b/courses/A.yaml
@@ -1,7 +1,7 @@
 - id: A01 Introduction to scientific computing
   desc: Get started with common scientific computing guidelines.
   reading: |
-    > `Good computing practices <https://doi.org/10.1371/journal.pcbi.1005510>`__ for everyone regardless of skills
+    >\ `Good computing practices <https://doi.org/10.1371/journal.pcbi.1005510>`__ for everyone regardless of skills
   questions: |
     >What kind of a workflow to follow?
     >Where to get help?

--- a/courses/B.yaml
+++ b/courses/B.yaml
@@ -2,8 +2,8 @@
   desc: Data needs to be organized and handled well, or else it quickly
     becomes unusable.  There are good and bad ways to do this.
   video: |
-    > `What is not data management, in 5 minutes <https://www.youtube.com/watch?v=N2zK3sAtr-4>`__ and
-    > `Data structuring <https://www.youtube.com/watch?v=3MEJ38BO6Mo&t=>`__
+    >\ `What is not data management, in 5 minutes <https://www.youtube.com/watch?v=N2zK3sAtr-4>`__ and
+    >\ `Data structuring <https://www.youtube.com/watch?v=3MEJ38BO6Mo&t=>`__
   reading: |
     >The Turing Way `data management chapter <https://the-turing-way.netlify.app/reproducible-research/rdm.html>`__
     >Information for research at `FSD <https://www.fsd.tuni.fi/aineistonhallinta/en/>`__
@@ -28,12 +28,12 @@
 - id: B30 Making figures
   desc: How to make publication-quality figures for your work.
   video: |
-    > `Inkscape tutorials <https://inkscape.org/learn/tutorials/>`_ covering Inkscape basics for making figures, flowcharts, etc.
+    >\ `Inkscape tutorials <https://inkscape.org/learn/tutorials/>`_ covering Inkscape basics for making figures, flowcharts, etc.
     >A series of `Matplotlib tutorials <https://www.youtube.com/playlist?list=PL-osiE80TeTvipOqomVEeZ1HRrcEvtZB_>`_ for plotting in
     Python.
-    > `ggplot2 tutorials <https://www.youtube.com/playlist?list=PLjgj6kdf_snaBCTJEi53DvRVgOuVbzyku>`_ in R.
+    >\ `ggplot2 tutorials <https://www.youtube.com/playlist?list=PLjgj6kdf_snaBCTJEi53DvRVgOuVbzyku>`_ in R.
   reading: |
-    >PLOS `guidelines for better figures <https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003833>`_  
+    >PLOS `guidelines for better figures <https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003833>`_
   questions: |
     >What kinds of tools exist for making figures and plots?
     >What are some dos and don'ts for plots and figures?
@@ -42,20 +42,20 @@
   desc: LaTeX is the standard method for making publications in the
     computational and physical sciences.
   video: |
-    > `LaTeX tutorial series <https://www.youtube.com/playlist?list=PLNnwglGGYoTtW7o4PHFOSWGevcdFa3v3D>`_ covering LaTeX formatting and constructing a report
+    >\ `LaTeX tutorial series <https://www.youtube.com/playlist?list=PLNnwglGGYoTtW7o4PHFOSWGevcdFa3v3D>`_ covering LaTeX formatting and constructing a report
   reading: |
     >Introduction to `LaTeX <https://tobi.oetiker.ch/lshort/lshort.pdf>`_ (online book)
     >Short summary of `LaTex features <https://www.latex-tutorial.com/quick-start/>`__
   questions: |
     >How to build a LaTeX document?
-    
+
 
 - id: B32 Scientific posters
   desc: Making a scientific poster is a common task, but not often
     taught.  There are better tools than PowerPoint.
   reading: |
-    > `Basics of creating a Research Poster <https://guides.nyu.edu/posters>`__
+    >\ `Basics of creating a Research Poster <https://guides.nyu.edu/posters>`__
   video: |
-    > `The dos and don'ts of making a scientific poster <https://www.youtube.com/watch?v=agtgnJP3KoQ>`__
+    >\ `The dos and don'ts of making a scientific poster <https://www.youtube.com/watch?v=agtgnJP3KoQ>`__
   questions: |
     >What makes a clear and concise poster?

--- a/courses/C.yaml
+++ b/courses/C.yaml
@@ -3,9 +3,9 @@
     Let's face it: the command line is the basis of most data
     science and programming.
   video: |
-    > `Shell crash course <https://youtu.be/56p6xX0aToI>`__
+    >\ `Shell crash course <https://youtu.be/56p6xX0aToI>`__
   reading: |
-    > `Shell crash course <https://scicomp.aalto.fi/scicomp/shell/>`__
+    >\ `Shell crash course <https://scicomp.aalto.fi/scicomp/shell/>`__
     >Software carpentry `Shell-novice <http://swcarpentry.github.io/shell-novice/>`__ 
     >The first part of our `shell course
     <https://scicomp.aalto.fi/training/linux-shell-tutorial.html>`__ is
@@ -22,7 +22,7 @@
   video: |
     >Get to know VS Code `tutorial series  <https://www.youtube.com/playlist?list=PLkEZWD8wbltm8T3mS7SMCpT6WlnyIP50T>`__
   reading: |
-    > `Software Carpentry
+    >\ `Software Carpentry
     shell-novice, "Create a text file" part of section 3
     <http://swcarpentry.github.io/shell-novice/>`__
     >Tutorial on `IDEs <https://coderefinery.github.io/IDEs/>`__
@@ -35,7 +35,7 @@
   desc: |
     If you can do it on the Linux shell, you can automate it.
   video: |
-    > `Shell scripting <https://www.youtube.com/playlist?list=PLUQy4zfrctjH-FsjpIZDZ0NBznvF4FdNP>`__ tutorials.
+    >\ `Shell scripting <https://www.youtube.com/playlist?list=PLUQy4zfrctjH-FsjpIZDZ0NBznvF4FdNP>`__ tutorials.
   reading: |
     >Continue with the `Science-IT Linux shell tutorial
     <https://scicomp.aalto.fi/training/linux-shell-tutorial.html#part-2-linux-shell-scripting>`__ part 2.
@@ -50,9 +50,9 @@
     scientific computing.
   video: |
     >Why use `version control <https://www.youtube.com/watch?v=zbKdDsNNOhg>`__
-    > `Git for beginners <https://www.youtube.com/watch?v=PWqS4NBhEY8>`__
+    >\ `Git for beginners <https://www.youtube.com/watch?v=PWqS4NBhEY8>`__
   reading: |
-    > `Introduction to version
+    >\ `Introduction to version
     control <https://coderefinery.github.io/git-intro/>`__ by CodeRefinery
   questions: |
     >What is Git?
@@ -64,9 +64,9 @@
     A short but important course: how to do work remotely.
     Different expert tips for making ssh better, too.
   reading: |
-    > `SSH <https://www.mn.uio.no/geo/english/services/it/help/using-linux/ssh-tips-and-tricks.html>`__ for working on a remote machine.
+    >\ `SSH <https://www.mn.uio.no/geo/english/services/it/help/using-linux/ssh-tips-and-tricks.html>`__ for working on a remote machine.
   video: |
-    > `Introduction to secure shell <https://www.youtube.com/watch?v=UHWR3Nj3bhE&list=PLA86D04D6E0BFD2E0&index=9>`__ by Software Carpentry
+    >\ `Introduction to secure shell <https://www.youtube.com/watch?v=UHWR3Nj3bhE&list=PLA86D04D6E0BFD2E0&index=9>`__ by Software Carpentry
   questions: |
     >What does SSH mean and when to use it?
 
@@ -75,7 +75,7 @@
   desc: |
     Automate the repetitive stuff with Make.
   video: |
-    > `Episodes <https://www.youtube.com/playlist?list=PLF47AC7312BE0799A>`__ on Make by Software Carpentry
+    >\ `Episodes <https://www.youtube.com/playlist?list=PLF47AC7312BE0799A>`__ on Make by Software Carpentry
   reading: |
     >Short `introduction <https://opensource.com/article/18/8/what-how-makefile>`__ on what is a Makefile and basic operations.
     >For more information on Makefiles see `GNU Make Manual <https://www.gnu.org/software/make/manual/make.html>`__

--- a/courses/D.yaml
+++ b/courses/D.yaml
@@ -1,73 +1,73 @@
 - id: D01 What is HPC?
   questions: |
-    > What are the scales of computing?
+    >\ What are the scales of computing?
   desc: |
     Before you can use larger resources, you need to understand the
     difference from your own computers
   reading: |
-    > `HPC Intro <https://scicomp.aalto.fi/triton/tut/intro.html>`__
+    >\ `HPC Intro <https://scicomp.aalto.fi/triton/tut/intro.html>`__
 
 
 - id: D20 Modules and software
   questions: |
-    > How do you use ``module``?
-    > How do you find software?
+    >\ How do you use ``module``?
+    >\ How do you find software?
   desc: |
     Using and installing software on a cluster is different from
     your own computer, because hundreds of people are sharing it.
     Modules are the solution.
   video: |
-    `Lmod introduction <https://youtu.be/Et5bXBOKHoc>`__
+    >\ `Lmod introduction <https://youtu.be/Et5bXBOKHoc>`__
   reading: |
-    > Triton tutorials for intro:
+    >\ Triton tutorials for intro:
     `modules <https://scicomp.aalto.fi/triton/tut/modules.html>`__,
     `applications <https://scicomp.aalto.fi/triton/tut/applications.html>`__,
-    > `Lmod user guide <https://lmod.readthedocs.io/en/latest/010_user.html>`__
+    >\ `Lmod user guide <https://lmod.readthedocs.io/en/latest/010_user.html>`__
 
 
 - id: D21 Batch systems
   questions: |
-    > What role does the batch system fill?
-    > How does one submit to the batch system?
+    >\ What role does the batch system fill?
+    >\ How does one submit to the batch system?
   desc: |
     On a cluster, you have to share resources with others.  Slurm
     is one batch queuing system that makes it possible.
   video: |
-    > `Slurm basics <https://youtu.be/49DzPT9HFJM>`__
-    > `interactive jobs <https://youtu.be/U2Bpg4sZ8Xg>`__
-    > `batch jobs <https://youtu.be/U2Bpg4sZ8Xg>`__
+    >\ `Slurm basics <https://youtu.be/49DzPT9HFJM>`__
+    >\ `interactive jobs <https://youtu.be/U2Bpg4sZ8Xg>`__
+    >\ `batch jobs <https://youtu.be/U2Bpg4sZ8Xg>`__
   reading: |
     Triton tutorials:
-    `interactive <https://scicomp.aalto.fi/triton/tut/interactive.html>`__,
-    `serial <https://scicomp.aalto.fi/triton/tut/serial.html>`__,
-    `array <https://scicomp.aalto.fi/triton/tut/array.html>`__
+    >\ `interactive <https://scicomp.aalto.fi/triton/tut/interactive.html>`__,
+    >\ `serial <https://scicomp.aalto.fi/triton/tut/serial.html>`__,
+    >\ `array <https://scicomp.aalto.fi/triton/tut/array.html>`__
 
 
 - id: D22 HPC Storage
   questions: |
-    > Why is storage so important?
-    > How can you monitor input/output (I/O) performance?
-    > How to best handle your data?
+    >\ Why is storage so important?
+    >\ How can you monitor input/output (I/O) performance?
+    >\ How to best handle your data?
   desc: |
     Storage turns out to be just as important as computing power.
     There are different places available, each with different
     advantages.
   video: |
-    > `HPC I/O principles <https://youtu.be/V_vWh0kWPBs>`__
+    >\ `HPC I/O principles <https://youtu.be/V_vWh0kWPBs>`__
   reading: |
-    `Storage basics <https://scicomp.aalto.fi/triton/tut/storage.html>`__.
+    >\ `Storage basics <https://scicomp.aalto.fi/triton/tut/storage.html>`__.
 
 - id: D23 Parallel computing
   questions: |
-    > What are the main models of parallel code?
-    > How are they run on clusters?
-    > How do you figure out what your code uses?
+    >\ What are the main models of parallel code?
+    >\ How are they run on clusters?
+    >\ How do you figure out what your code uses?
   desc: |
     The point of a cluster is to run things in parallel.  Shared
     memory (OpenMP) and message passing (MPI) are the most common models.
     Learn how to run them, not write them.
   reading: |
-    `Parallel jobs <https://scicomp.aalto.fi/triton/tut/parallel.html>`__.
+    >\ `Parallel jobs <https://scicomp.aalto.fi/triton/tut/parallel.html>`__.
 
 
 - id: D24 Advanced shell scripting and automation

--- a/courses/E.yaml
+++ b/courses/E.yaml
@@ -3,9 +3,9 @@
     Break your large programs into small problems by separating aspects of desired functionality
     to different sub-modules.
   reading: |
-    > `Lesson <http://coderefinery.org/lessons/>`__ on Modular code development by CodeRefinery
+    >\ `Lesson <http://coderefinery.org/lessons/>`__ on Modular code development by CodeRefinery
   video: |
-    > `Python example <https://www.youtube.com/watch?v=mz_T554Qe6A>`__ of breaking code into small components
+    >\ `Python example <https://www.youtube.com/watch?v=mz_T554Qe6A>`__ of breaking code into small components
   questions: |
     >How to divide code into independent modules?
     >What are pure functions like?
@@ -13,12 +13,12 @@
 
 - id: E61 Software testing
   desc: |
-    It is important to ensure that your program performs effectively and without failures. 
+    It is important to ensure that your program performs effectively and without failures.
     Adding tests for your software can save a lot of your time later.
   video: |
     >Software testing `fundamentals <https://www.youtube.com/playlist?list=PLB384772FCCE1414E>`__ by Software Carpentry
   reading: |
-    > `Lesson <https://coderefinery.github.io/testing/>`__ on testing by CodeRefinery
+    >\ `Lesson <https://coderefinery.github.io/testing/>`__ on testing by CodeRefinery
   questions: |
     >How to test code on different levels?
     >What kind of testing tools are there?
@@ -27,7 +27,7 @@
 - id: E62 Profiling
   desc: Code efficiency is critical especially in HPC. Learn to measure the performance of your programs.
   video: |
-    > `Profiling Python code <https://www.youtube.com/watch?v=8qEnExGLZfY>`__ with cProfile
+    >\ `Profiling Python code <https://www.youtube.com/watch?v=8qEnExGLZfY>`__ with cProfile
   reading: |
     >Profiling tools for `Linux <http://www.brendangregg.com/linuxperf.html>`__
     >Profiling for `C and Python <http://rkd.zgib.net/scicomp/profiling/profiling.html>`__
@@ -36,50 +36,50 @@
 
 
 - id: E63 Debugging
-  desc: 
+  desc:
     Detect, investigate and resolve bugs.
   video: |
-    > `Debugging <https://www.youtube.com/watch?v=jlBgMf_atSo>`__ strategies
+    >\ `Debugging <https://www.youtube.com/watch?v=jlBgMf_atSo>`__ strategies
   reading: |
-    > `Debugging <http://rkd.zgib.net/scicomp/debugging/debugging.html>`__ in a nutshell.
+    >\ `Debugging <http://rkd.zgib.net/scicomp/debugging/debugging.html>`__ in a nutshell.
     >See `Triton's debugging guide <https://scicomp.aalto.fi/triton/usage/debugging.html>`__
   questions: |
     >How to debug different types of errors?
 
 
 - id: E02 Software Licensing
-  desc: 
+  desc:
     Sharing your work can be very beneficial. Take a look at social coding and software licensing.
   video: |
-    >Brief `introduction <https://www.youtube.com/watch?v=f2NkKTn-mw8>`__ to differences between open and closed source software 
+    >Brief `introduction <https://www.youtube.com/watch?v=f2NkKTn-mw8>`__ to differences between open and closed source software
   reading: |
-    > `Lesson <https://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/social-coding/master/talk.md/#1>`__ on social coding by CodeRefinery
+    >\ `Lesson <https://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/social-coding/master/talk.md/#1>`__ on social coding by CodeRefinery
   questions: |
     >What is free software?
     >Why should you share your code?
 
 
 - id: E04 Documentation
-  desc: 
-    Document your project so other people can easily use the code and even contribute to it. 
+  desc:
+    Document your project so other people can easily use the code and even contribute to it.
   video: |
     >Documentation with `Sphinx  <https://www.youtube.com/watch?v=b4iFyrLQQh4>`__
   reading: |
     >Why is `documentation <https://www.youtube.com/watch?v=lWEOx6r_eEk>`__ necessary in your project
     >Documentation with `Sphinx  <https://www.youtube.com/watch?v=b4iFyrLQQh4>`__
   reading: |
-    > `Tools <https://guides.lib.berkeley.edu/how-to-write-good-documentation>`__ for documentation
+    >\ `Tools <https://guides.lib.berkeley.edu/how-to-write-good-documentation>`__ for documentation
     >CodeRefinery lesson on `documentation <https://coderefinery.github.io/documentation/>`__
   questions: |
     >What should be included in a documentation?
 
 
 - id: E03 Reproducible research
-  desc: 
-    How different tools can improve reproducibility. 
+  desc:
+    How different tools can improve reproducibility.
   video: |
     >What is `reproducible research <https://www.youtube.com/watch?v=4rBX6r5emgQ>`__
   reading: |
-    > `Lesson <https://coderefinery.github.io/reproducible-research/>`__ by CodeRefinery
+    >\ `Lesson <https://coderefinery.github.io/reproducible-research/>`__ by CodeRefinery
   questions: |
     >Which tools can help with reproducibility?

--- a/courses/F.yaml
+++ b/courses/F.yaml
@@ -9,19 +9,19 @@
   desc: This was an advanced guest course, useful if you want to know
     how to program GPU applications.
   reading: |
-    `Materials here
-    <http://science-it.aalto.fi/scip/gpu-computing-fall-2017/>`__.
+    >\ `Materials here
+    <http://science-it.aalto.fi/scip/gpu-computing-fall-2017/>`__
 
 - id: Fxx MPI Programming
   desc: This was an advanced guest course, useful if you want to know
     internals of MPI or program MPI applications.
   reading: |
-    `Materials here
-    <http://science-it.aalto.fi/scip/mpi-intro-spring-2018/>`__.
+    >\ `Materials here
+    <http://science-it.aalto.fi/scip/mpi-intro-spring-2018/>`__
 
 - id: Fxx HTCondor
   desc: Condor allows you to use many workstations as a high throughput
     cluster, ideal for mid-range embarrassingly parallel problems.
   reading: |
-    `Materials here
-    <http://science-it.aalto.fi/scip/condor2017/>`__.
+    >\ `Materials here
+    <http://science-it.aalto.fi/scip/condor2017/>`__


### PR DESCRIPTION
- Universally adopt the `>` prefix for each item in the tables, and
  also remove any space between that and links.
- Other minor whitespace cleanup.