### PR TITLE
requirements: Pin docutils to 0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx
 sphinx_rtd_theme
-docutils!=0.15        # 2019-07-21, upstream breakage with Sphinx #6594
+docutils==0.16        # 2019-07-21, upstream breakage with Sphinx #6594
 PyYAML
 sphinx_ext_substitution


### PR DESCRIPTION
- Fix sphinx_rtd_theme breakage in newer docutils
