### PR TITLE
Add virtual coderefinery course at /coderefinery/

### DIFF
--- a/source/coderefinery.rst
+++ b/source/coderefinery.rst
@@ -2,8 +2,8 @@ CodeRefinery
 ============
 
 `CodeRefinery <https://coderefinery.org>`__ is a course on tools
-needed to do efficient programming/software development, with a focus
-on researchers.  In-person and online courses are occasionally
+needed to do efficient research software development.
+In-person and online courses are occasionally
 offered, however, all material + videos are available online.  This
 page collects this material for self-study purposes.
 

--- a/source/coderefinery.rst
+++ b/source/coderefinery.rst
@@ -5,36 +5,41 @@ CodeRefinery
 needed to do efficient research software development.
 In-person and online courses are occasionally
 offered, however, all material + videos are available online.  This
-page collects this material for self-study purposes.
-
-In the Hands-on Scientific Computing scheme, most of this material is
-the E-level, with the git-intro being C-level.
-
-
-
-How to use this material
-------------------------
-
-You may go through this at your own page: written and video material
-are roughly the same and compliments each other; use one or the other
-or both in whatever order suits your styles.  Written material could
-be used without the videos.  If you are watching the videos and trying
-to do examples, it would be good to open the lesson too. "Q&A" are the
-live Q&A/notes asked by workshop attendees and answered during the
-workshop.
-
-Videos are portrait-mode, so that half of your screen is available for
-your own work.  You may need to do some trial and error to adjust your
-screen properly.
+page collects this material so that you can study on your own.
 
 This page contains an index to all material in one place, in the order
 it is actually presented, and updated with the current "best" material
 as we produce new versions of videos / material.
 
 
+How to use this material
+------------------------
+
+You may go through this at your own page: written and video material
+are roughly the same and compliment each other; use one or the other
+or both in whatever order suits your styles.
+
+* **Written lesson material** could be used without the videos.
+* **Videos** are self-sufficient for an overview but to do examples you
+  also want to open the written material.  They are portrait-mode so
+  that you can adjust your screen to have half of it for you.
+* **Q&A** are the live Q&A/notes asked by workshop attendees and
+  answered during the workshop, and are optional (could be used for
+  advanced study).
+
+In the Hands-on Scientific Computing scheme, most of this material is
+the E-level, with the git-intro being C-level.  This page is outside
+of the main Hands-on SciComp flow and there are no credits directly
+offered for this page.
+
+
 
 Git introduction
 ----------------
+
+The git version control system, from the very basics.  How to use it
+well for your own projects.
+
 * `Overall workshop intro <https://www.youtube.com/watch?v=q_DFH1SgTvc&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=1>`__
 * `Lesson <https://coderefinery.github.io/git-intro/>`__
 * `Video day 1 <https://www.youtube.com/watch?v=QcwQ8jeaHmc&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=2>`__
@@ -45,42 +50,71 @@ Git introduction
 Git collaborative
 -----------------
 
+How to use Git with multiple people.
+
 * `Lesson <https://coderefinery.github.io/git-collaborative/>`__
 * `Video <https://www.youtube.com/watch?v=BS7tlcEKrYA&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=6>`__
 * `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day3/>`__
 
 Reproducible research and FAIR data
 -----------------------------------
+
+It is easy to do things once, but it's important to be able to do
+them many times, or for others to be able to do them.
+
 * `Lesson <https://coderefinery.github.io/reproducible-research/>`__
 * `Video <https://www.youtube.com/watch?v=MxZF1gEJoWw&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=8>`__
 * `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day4/#reproducible-research-motivation>`__
 
 Social coding and open software
 -------------------------------
+
+Eventually, you need to use the code or results that someone else has
+made - or need for others to be able to use your creations!
+
 * `Lesson <https://coderefinery.github.io/social-coding/>`__
 * `Video <https://www.youtube.com/watch?v=XkT8wMRcJok&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=9>`__
 * `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day4/#social-coding>`__
 
 Jupyter
 -------
+
+Jupyter is a system for interactive computing.
+
 * `Lesson <https://coderefinery.github.io/jupyter/>`__
 * `Video <https://www.youtube.com/watch?v=Vv2eGDiE3IU&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=11>`__
 * `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day5/#jupyter-notebooks>`__
 
 Documentation
 -------------
+
+Documentation is often the difference between reusable (or usable by
+yourself in six months) and not.  We go over various ways to make
+documentation much more enjoyable.
+
 * `Lesson <https://coderefinery.github.io/documentation/>`__
 * `Video <https://www.youtube.com/watch?v=0IZeQlXmtd4&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=12>`__
 * `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day5/#documentation>`__
 
 Software testing
 ----------------
+
+Automatic testing is one of the cornerstones of modern software
+development and without it, you often end up sending more and more
+time fixing old bugs rather than doing new things.  Here, we the
+concepts and simple strategies for getting started.
+
 * `Lesson <https://coderefinery.github.io/testing/>`__
 * `Video <https://www.youtube.com/watch?v=s72AqTTi_Y8&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=14>`__
 * `Q&A  <https://coderefinery.github.io/2021-05-10-workshop/questions/day6/#software-testing>`__
 
 Modular code development
 ------------------------
+
+When you can mix-and-match and reuse code, your productivity goes way
+up, and that is enabled by modularity.  Here, we give a basic intro to
+the concept and how to do so.
+
 * `Lesson <https://coderefinery.github.io/modular-type-along/>`__
 * `Video <https://www.youtube.com/watch?v=BlomsX5Xm-Q&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=15>`__
 * `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day6/#modular-code-development>`__

--- a/source/coderefinery.rst
+++ b/source/coderefinery.rst
@@ -1,0 +1,130 @@
+CodeRefinery
+============
+
+`CodeRefinery <https://coderefinery.org>`__ is a course on tools
+needed to do efficient programming/software development, with a focus
+on researchers.  In-person and online courses are occasionally
+offered, however, all material + videos are available online.  This
+page collects this material for self-study purposes.
+
+In the Hands-on Scientific Computing scheme, most of this material is
+the E-level, with the git-intro being C-level.
+
+
+
+How to use this material
+------------------------
+
+You may go through this at your own page: written and video material
+are roughly the same and compliments each other; use one or the other
+or both in whatever order suits your styles.  Written material could
+be used without the videos.  If you are watching the videos and trying
+to do examples, it would be good to open the lesson too. "Q&A" are the
+live Q&A/notes asked by workshop attendees and answered during the
+workshop.
+
+Videos are portrait-mode, so that half of your screen is available for
+your own work.  You may need to do some trial and error to adjust your
+screen properly.
+
+This page contains an index to all material in one place, in the order
+it is actually presented, and updated with the current "best" material
+as we produce new versions of videos / material.
+
+
+
+Git introduction
+----------------
+* `Overall workshop intro <https://www.youtube.com/watch?v=q_DFH1SgTvc&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=1>`__
+* `Lesson <https://coderefinery.github.io/git-intro/>`__
+* `Video day 1 <https://www.youtube.com/watch?v=QcwQ8jeaHmc&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=2>`__
+* `Video day 2 <https://www.youtube.com/watch?v=MeHB_Fjssjw&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=4>`__
+* `Day 1 Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day1/>`__
+* `Day 2 Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day2/>`__
+
+Git collaborative
+-----------------
+
+* `Lesson <https://coderefinery.github.io/git-collaborative/>`__
+* `Video <https://www.youtube.com/watch?v=BS7tlcEKrYA&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=6>`__
+* `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day3/>`__
+
+Reproducible research and FAIR data
+-----------------------------------
+* `Lesson <https://coderefinery.github.io/reproducible-research/>`__
+* `Video <https://www.youtube.com/watch?v=MxZF1gEJoWw&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=8>`__
+* `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day4/#reproducible-research-motivation>`__
+
+Social coding and open software
+-------------------------------
+* `Lesson <https://coderefinery.github.io/social-coding/>`__
+* `Video <https://www.youtube.com/watch?v=XkT8wMRcJok&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=9>`__
+* `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day4/#social-coding>`__
+
+Jupyter
+-------
+* `Lesson <https://coderefinery.github.io/jupyter/>`__
+* `Video <https://www.youtube.com/watch?v=Vv2eGDiE3IU&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=11>`__
+* `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day5/#jupyter-notebooks>`__
+
+Documentation
+-------------
+* `Lesson <https://coderefinery.github.io/documentation/>`__
+* `Video <https://www.youtube.com/watch?v=0IZeQlXmtd4&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=12>`__
+* `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day5/#documentation>`__
+
+Software testing
+----------------
+* `Lesson <https://coderefinery.github.io/testing/>`__
+* `Video <https://www.youtube.com/watch?v=s72AqTTi_Y8&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=14>`__
+* `Q&A  <https://coderefinery.github.io/2021-05-10-workshop/questions/day6/#software-testing>`__
+
+Modular code development
+------------------------
+* `Lesson <https://coderefinery.github.io/modular-type-along/>`__
+* `Video <https://www.youtube.com/watch?v=BlomsX5Xm-Q&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=15>`__
+* `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day6/#modular-code-development>`__
+
+Concluding remarks and where to go from here
+--------------------------------------------
+* `Lesson <https://github.com/coderefinery/workshop-outro/blob/master/README.md>`__
+* `Video <https://www.youtube.com/watch?v=aJoq7dLnWf4&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=16>`__
+* `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/day6/#concluding-remarks>`__
+
+
+
+Other
+-----
+* `Expanded Q&A from the May 2021 workshop <https://www.youtube.com/watch?v=p03ebpjuRgA&list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ&index=17>`__
+
+
+
+Source material
+---------------
+
+Source material from past workshops (in general newer is probably
+better):
+
+* `All CodeRefinery lessons <https://coderefinery.org/lessons/>`__
+  (includes a few minor ones not in the main workshop flow).
+
+* May 2021
+
+  * `Workshop page <https://coderefinery.github.io/2021-05-10-workshop/>`__
+  * `YouTube playlist
+    <https://www.youtube.com/playlist?list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ>`__
+  * `Q&A <https://coderefinery.github.io/2021-05-10-workshop/questions/>`__
+
+* May 2020
+
+  * `Workshop page <https://coderefinery.github.io/2020-05-25-online/>`__
+  * `YouTube playlist <https://www.youtube.com/playlist?list=PLpLblYHCzJAAfke64bWU0mTPQE5kVZs_p>`__
+
+
+
+See also
+--------
+
+Subscribe to the `CodeRefinery newsletter
+<https://coderefinery.org>`__ to be updated of when workshops are
+opened.

--- a/source/index.rst
+++ b/source/index.rst
@@ -262,4 +262,10 @@ be interesting to you.
    about
    fitech-info
 
+.. toctree::
+   :hidden:
+   :caption: Other virtual courses
+
+   coderefinery
+
 * :ref:`genindex`


### PR DESCRIPTION
- Add a link to all CodeRefinery material + videos, as a landing page
  for a "virtual coderefinery course".  This links to lessons and our
  good videos from 2021.  By centralizing this in one place we are
  able to update it easily.

- I am not entirely sure it goes here, but it does make the
  possibility to have one central place that has both the overall map,
  and deeper dives into specific topics (like CodeRefinery).

- Review:
  - Is this the right place for this material?

  - Please read and revise the other related text at the top of the
    page.
